### PR TITLE
Removed reference to internal repository

### DIFF
--- a/docs/testsuite_overview.md
+++ b/docs/testsuite_overview.md
@@ -38,7 +38,7 @@ Make sure you have installed [gradle](https://gradle.org/), which is used for bu
  
 Download the test suite from its git repository: 
 ```
-git clone ssh://git.corp.linkedin.com:29418/restli-testsuite/restli-testsuite
+git clone <coming soon>
 cd restli-testsuite
 ```
 


### PR DESCRIPTION
When the rest.li site is live, this git instruction will be inaccurate because the referenced repo is internal. When the test suite is open source, we can fill in the appropriate repository name.  